### PR TITLE
add ruby hashkey and instance variable colors

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -1,4 +1,5 @@
 @import "syntax-variables";
+@import "ruby";
 
 atom-text-editor, :host {
   background-color: @syntax-background-color;

--- a/styles/ruby.less
+++ b/styles/ruby.less
@@ -1,0 +1,20 @@
+.source.ruby {
+
+  .variable.instance.ruby,
+  .meta.embedded .variable.instance {
+    color: @light-orange;
+
+    .punctuation {
+      color: @light-orange;
+    }
+  }
+
+  .constant.symbol.hashkey {
+
+    &,
+    .punctuation.definition.constant.hashkey.ruby {
+      color: @red;
+    }
+  }
+
+}


### PR DESCRIPTION
Created a  new file for specific ruby only syntax. 
Highlight ruby instance variables (`@variables`) and hashkeys (`key: :value`) with ruby and ruby on rails syntaxes.

Before:
![screen shot 2015-09-08 at 9 56 44 am](https://cloud.githubusercontent.com/assets/1993929/9739153/3e3c57c8-5614-11e5-8b63-a86ed934c64e.png)

After:
![screen shot 2015-09-08 at 10 23 53 am](https://cloud.githubusercontent.com/assets/1993929/9739154/3e4008fa-5614-11e5-9140-7d2a7bfe2806.png)
