### PR TITLE
Adds green colour

### DIFF
--- a/styles/colors.less
+++ b/styles/colors.less
@@ -15,7 +15,7 @@
 @blue:   @cyan;
 @purple: @cyan;
 @orange: hsl(16, 77%, 65%);
-@green:  @orange;
+@green:  #cae359;
 @red:    #cc6666;
 //@light-orange: hsl(37, 46%, 70%);
 @light-orange: hsl(42, 50%, 70%);


### PR DESCRIPTION
Thank for this syntax theme, it's easily the best theme I've found for Atom.

Only thing that drives me mad is the green colour being set to orange. This really affects my development and use of Atom as I can't easily pick out new files and lines. For such a great theme this seems to be a large and unnecessary downside.

I've selected a green to use in this PR by using the base orange colour and applying into a triad colour wheel with 60 degree span (http://paletton.com/#uid=30g0X0kjxtC9FM2f0Aanzqdr3lk). The result is a green that fits with the rest of the colour scheme.

<img width="186" alt="tree" src="https://cloud.githubusercontent.com/assets/244198/9748383/34bd417c-567c-11e5-91b5-6b3753397260.png">

<img width="110" alt="gutter" src="https://cloud.githubusercontent.com/assets/244198/9748363/17f594ae-567c-11e5-8de0-6fd27bc8f217.png">

Thanks!
