### PR TITLE
fix ruby interpolated strings

### DIFF
--- a/styles/ruby.less
+++ b/styles/ruby.less
@@ -17,4 +17,7 @@
     }
   }
 
+  // .meta.embedded .source.ruby {
+  //   color: @white;
+  // }
 }


### PR DESCRIPTION
Fix ruby string interpolation

before:
<img width="244" alt="screen shot 2016-10-21 at 6 45 37 pm" src="https://cloud.githubusercontent.com/assets/1993929/19614970/adf66570-97bf-11e6-89f1-b0666e5006bf.png">

after:
<img width="242" alt="screen shot 2016-10-21 at 6 45 52 pm" src="https://cloud.githubusercontent.com/assets/1993929/19614972/ae1d3a56-97bf-11e6-8877-69639e81d33a.png">
